### PR TITLE
Add GCM notification payload support

### DIFF
--- a/src/main/java/org/whispersystems/gcm/server/Message.java
+++ b/src/main/java/org/whispersystems/gcm/server/Message.java
@@ -32,22 +32,24 @@ public class Message {
   private final String              collapseKey;
   private final Long                ttl;
   private final Boolean             delayWhileIdle;
+  private final Map<String, String> notification;
   private final Map<String, String> data;
   private final List<String>        registrationIds;
 
   private Message(String collapseKey, Long ttl, Boolean delayWhileIdle,
-                  Map<String, String> data, List<String> registrationIds)
+                  Map<String, String> notification, Map<String, String> data, List<String> registrationIds)
   {
     this.collapseKey     = collapseKey;
     this.ttl             = ttl;
     this.delayWhileIdle  = delayWhileIdle;
+    this.notification    = notification;
     this.data            = data;
     this.registrationIds = registrationIds;
   }
 
   public String serialize() throws JsonProcessingException {
     GcmRequestEntity requestEntity = new GcmRequestEntity(collapseKey, ttl, delayWhileIdle,
-                                                          data, registrationIds);
+                                                          notification, data, registrationIds);
 
     return objectMapper.writeValueAsString(requestEntity);
   }
@@ -62,9 +64,23 @@ public class Message {
 
   public static class Builder {
 
+    private static final String NOTIFICATION_TITLE = "title";
+    private static final String NOTIFICATION_BODY = "body";
+    private static final String NOTIFICATION_ICON = "icon";
+    private static final String NOTIFICATION_SOUND = "sound";
+    private static final String NOTIFICATION_BADGE = "badge";
+    private static final String NOTIFICATION_TAG = "tag";
+    private static final String NOTIFICATION_COLOR = "color";
+    private static final String NOTIFICATION_CLICK_ACTION = "click_action";
+    private static final String NOTIFICATION_TITLE_LOC_KEY = "title_loc_key";
+    private static final String NOTIFICATION_TITLE_LOC_ARGS = "title_loc_args";
+    private static final String NOTIFICATION_BODY_LOC_KEY = "body_loc_key";
+    private static final String NOTIFICATION_BODY_LOC_ARGS = "body_loc_args";
+
     private String              collapseKey     = null;
     private Long                ttl             = null;
     private Boolean             delayWhileIdle  = null;
+    private Map<String, String> notification    = null;
     private Map<String, String> data            = null;
     private List<String>        registrationIds = new LinkedList<>();
 
@@ -94,6 +110,128 @@ public class Message {
      */
     public Builder withDelayWhileIdle(boolean delayWhileIdle) {
       this.delayWhileIdle = delayWhileIdle;
+      return this;
+    }
+
+    /**
+     * Set the title in the notification payload automatically displayed by GCM (optional).
+     * @param title The title to set.
+     * @return The Builder.
+     */
+    public Builder withNotificationTitle(String title) {
+      return withNotificationPart(NOTIFICATION_TITLE, title);
+    }
+
+    /**
+     * Set the body in the notification payload automatically displayed by GCM (optional).
+     * @param body The body to set.
+     * @return The Builder.
+     */
+    public Builder withNotificationBody(String body) {
+      return withNotificationPart(NOTIFICATION_BODY, body);
+    }
+
+    /**
+     * Set the icon in the notification payload automatically displayed by GCM (optional).
+     * @param icon The icon to set.
+     * @return The Builder.
+     */
+    public Builder withNotificationIcon(String icon) {
+      return withNotificationPart(NOTIFICATION_ICON, icon);
+    }
+
+    /**
+     * Set the sound in the notification payload automatically displayed by GCM (optional).
+     * @param sound The sound to set.
+     * @return The Builder.
+     */
+    public Builder withNotificationSound(String sound) {
+      return withNotificationPart(NOTIFICATION_SOUND, sound);
+    }
+
+    /**
+     * Set the badge in the notification payload automatically displayed by GCM (optional).
+     * @param badge The badge to set.
+     * @return The Builder.
+     */
+    public Builder withNotificationBadge(String badge) {
+      return withNotificationPart(NOTIFICATION_BADGE, badge);
+    }
+
+    /**
+     * Set the tag in the notification payload automatically displayed by GCM (optional).
+     * @param tag The tag to set.
+     * @return The Builder.
+     */
+    public Builder withNotificationTag(String tag) {
+      return withNotificationPart(NOTIFICATION_TAG, tag);
+    }
+
+    /**
+     * Set the color in the notification payload automatically displayed by GCM (optional).
+     * @param color The color to set.
+     * @return The Builder.
+     */
+    public Builder withNotificationColor(String color) {
+      return withNotificationPart(NOTIFICATION_COLOR, color);
+    }
+
+    /**
+     * Set the click_action in the notification payload automatically displayed by GCM (optional).
+     * @param clickAction The click_action to set.
+     * @return The Builder.
+     */
+    public Builder withNotificationClickAction(String clickAction) {
+      return withNotificationPart(NOTIFICATION_CLICK_ACTION, clickAction);
+    }
+
+    /**
+     * Set the title_loc_key in the notification payload automatically displayed by GCM (optional).
+     * @param titleLocKey The title_loc_key to set.
+     * @return The Builder.
+     */
+    public Builder withNotificationTitleLocKey(String titleLocKey) {
+      return withNotificationPart(NOTIFICATION_TITLE_LOC_KEY, titleLocKey);
+    }
+
+    /**
+     * Set the title_loc_args in the notification payload automatically displayed by GCM (optional).
+     * @param titleLocArgs The title_loc_args to set.
+     * @return The Builder.
+     */
+    public Builder withNotificationTitleLocArgs(String titleLocArgs) {
+      return withNotificationPart(NOTIFICATION_TITLE_LOC_ARGS, titleLocArgs);
+    }
+
+    /**
+     * Set the body_loc_key in the notification payload automatically displayed by GCM (optional).
+     * @param bodyLocKey The body_loc_key to set.
+     * @return The Builder.
+     */
+    public Builder withNotificationBodyLocKey(String bodyLocKey) {
+      return withNotificationPart(NOTIFICATION_BODY_LOC_KEY, bodyLocKey);
+    }
+
+    /**
+     * Set body_loc_args in the notification payload automatically displayed by GCM (optional).
+     * @param bodyLocArgs The body_loc_args to set.
+     * @return The Builder.
+     */
+    public Builder withNotificationBodyLocArgs(String bodyLocArgs) {
+      return withNotificationPart(NOTIFICATION_BODY_LOC_ARGS, bodyLocArgs);
+    }
+
+    /**
+     * Set a key in the notification payload automatically displayed by GCM (optional).
+     * @param key The key to set.
+     * @param value The value to set.
+     * @return The Builder.
+     */
+    private Builder withNotificationPart(String key, String value) {
+      if (notification == null) {
+        notification = new HashMap<>();
+      }
+      notification.put(key, value);
       return this;
     }
 
@@ -132,7 +270,7 @@ public class Message {
         throw new IllegalArgumentException("You must specify a destination!");
       }
 
-      return new Message(collapseKey, ttl, delayWhileIdle, data, registrationIds);
+      return new Message(collapseKey, ttl, delayWhileIdle, notification, data, registrationIds);
     }
   }
 

--- a/src/main/java/org/whispersystems/gcm/server/internal/GcmRequestEntity.java
+++ b/src/main/java/org/whispersystems/gcm/server/internal/GcmRequestEntity.java
@@ -35,18 +35,22 @@ public class GcmRequestEntity {
   @JsonProperty(value = "delay_while_idle")
   private Boolean delayWhileIdle;
 
+  @JsonProperty(value = "notification")
+  private Map<String, String> notification;
+
   @JsonProperty(value = "data")
   private Map<String, String> data;
 
   @JsonProperty(value = "registration_ids")
   private List<String> registrationIds;
 
-  public GcmRequestEntity(String collapseKey, Long ttl, Boolean delayWhileIdle,
+  public GcmRequestEntity(String collapseKey, Long ttl, Boolean delayWhileIdle, Map<String, String> notification,
                           Map<String, String> data, List<String> registrationIds)
   {
     this.collapseKey     = collapseKey;
     this.ttl             = ttl;
     this.delayWhileIdle  = delayWhileIdle;
+    this.notification    = notification;
     this.data            = data;
     this.registrationIds = registrationIds;
   }

--- a/src/test/java/org/whispersystems/gcm/server/MessageTest.java
+++ b/src/test/java/org/whispersystems/gcm/server/MessageTest.java
@@ -3,8 +3,10 @@ package org.whispersystems.gcm.server;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.HashMap;
 
 import static org.junit.Assert.assertEquals;
+import static org.whispersystems.gcm.server.util.JsonHelpers.fromJson;
 import static org.whispersystems.gcm.server.util.JsonHelpers.jsonFixture;
 
 public class MessageTest {
@@ -27,7 +29,8 @@ public class MessageTest {
                              .withTtl(10)
                              .build();
 
-    assertEquals(message.serialize(), jsonFixture("fixtures/message-complete.json"));
+    assertEquals(fromJson(message.serialize(), HashMap.class),
+                 fromJson(jsonFixture("fixtures/message-complete.json"), HashMap.class));
   }
 
   @Test
@@ -38,7 +41,54 @@ public class MessageTest {
                              .withDataPart("key2", "value2")
                              .build();
 
-    assertEquals(message.serialize(), jsonFixture("fixtures/message-data.json"));
+    assertEquals(fromJson(message.serialize(), HashMap.class),
+                 fromJson(jsonFixture("fixtures/message-data.json"), HashMap.class));
+  }
+
+  @Test
+  public void testWithNotification() throws IOException {
+    Message message = Message.newBuilder()
+            .withDestination("3")
+            .withNotificationTitle("title")
+            .withNotificationBody("body")
+            .withNotificationIcon("icon")
+            .withNotificationSound("sound")
+            .withNotificationBadge("badge")
+            .withNotificationTag("tag")
+            .withNotificationColor("color")
+            .withNotificationClickAction("click-action")
+            .withNotificationTitleLocKey("title-loc-key")
+            .withNotificationTitleLocArgs("title-loc-args")
+            .withNotificationBodyLocKey("body-loc-key")
+            .withNotificationBodyLocArgs("body-loc-args")
+            .build();
+
+    assertEquals(fromJson(message.serialize(), HashMap.class),
+                 fromJson(jsonFixture("fixtures/message-notification.json"), HashMap.class));
+  }
+
+  @Test
+  public void testWithNotificationAndData() throws IOException {
+    Message message = Message.newBuilder()
+            .withDestination("3")
+            .withNotificationTitle("title")
+            .withNotificationBody("body")
+            .withNotificationIcon("icon")
+            .withNotificationSound("sound")
+            .withNotificationBadge("badge")
+            .withNotificationTag("tag")
+            .withNotificationColor("color")
+            .withNotificationClickAction("click-action")
+            .withNotificationTitleLocKey("title-loc-key")
+            .withNotificationTitleLocArgs("title-loc-args")
+            .withNotificationBodyLocKey("body-loc-key")
+            .withNotificationBodyLocArgs("body-loc-args")
+            .withDataPart("key1", "value1")
+            .withDataPart("key2", "value2")
+            .build();
+
+    assertEquals(fromJson(message.serialize(), HashMap.class),
+                 fromJson(jsonFixture("fixtures/message-notification-and-data.json"), HashMap.class));
   }
 
 }

--- a/src/test/resources/fixtures/message-notification-and-data.json
+++ b/src/test/resources/fixtures/message-notification-and-data.json
@@ -1,0 +1,21 @@
+{
+  "notification" : {
+    "badge" : "badge",
+    "title_loc_args" : "title-loc-args",
+    "body_loc_args" : "body-loc-args",
+    "color" : "color",
+    "sound" : "sound",
+    "icon" : "icon",
+    "tag" : "tag",
+    "title_loc_key" : "title-loc-key",
+    "title" : "title",
+    "body" : "body",
+    "click_action" : "click-action",
+    "body_loc_key" : "body-loc-key"
+  },
+  "data" : {
+    "key1" : "value1",
+    "key2" : "value2"
+  },
+  "registration_ids" : ["3"]
+}

--- a/src/test/resources/fixtures/message-notification.json
+++ b/src/test/resources/fixtures/message-notification.json
@@ -1,0 +1,17 @@
+{
+  "notification" : {
+    "badge" : "badge",
+    "title_loc_args" : "title-loc-args",
+    "body_loc_args" : "body-loc-args",
+    "color" : "color",
+    "sound" : "sound",
+    "icon" : "icon",
+    "tag" : "tag",
+    "title_loc_key" : "title-loc-key",
+    "title" : "title",
+    "body" : "body",
+    "click_action" : "click-action",
+    "body_loc_key" : "body-loc-key"
+  },
+  "registration_ids" : ["3"]
+}


### PR DESCRIPTION
GCM now supports a payload field `notification` which allows GCM to understand the details of the notification and automatically display it on behalf of the client app:

https://developers.google.com/cloud-messaging/concept-options

This PR adds support for setting this `notification` field in the message payload.
