### PR TITLE
Allow a wide range of characters by specifying message charset

### DIFF
--- a/src/main/java/org/whispersystems/gcm/server/Sender.java
+++ b/src/main/java/org/whispersystems/gcm/server/Sender.java
@@ -124,7 +124,7 @@ public class Sender {
 
         request.setHeader("Authorization", authorizationHeader);
         request.setEntity(new StringEntity(message.serialize(),
-                                           ContentType.parse("application/json")));
+                                           ContentType.parse("application/json; charset=utf-8")));
 
         client.execute(request, new ResponseHandler(future, requestContext));
 

--- a/src/test/java/org/whispersystems/gcm/server/SenderTest.java
+++ b/src/test/java/org/whispersystems/gcm/server/SenderTest.java
@@ -46,7 +46,7 @@ public class SenderTest {
     assertEquals(request.getPath(), "/gcm/send");
     assertEquals(new String(request.getBody()), jsonFixture("fixtures/message-minimal.json"));
     assertEquals(request.getHeader("Authorization"), "key=foobarbaz");
-    assertEquals(request.getHeader("Content-Type"), "application/json");
+    assertEquals(request.getHeader("Content-Type"), "application/json; charset=utf-8");
     assertEquals(server.getRequestCount(), 1);
   }
 


### PR DESCRIPTION
Small fix to specify the charset as part of the content type. This stops characters with diacritics being removed from the message text.